### PR TITLE
When single download - use download manager

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,22 @@ function download(downloadsArray, callback) {
     Promise.all(downloadsArray.map(Task.async(function*(value, index, array) {
         let finalDest = yield getValidFilename(downloadFolder, value.filename, 0);
         console.log(`Downloading ${value.downloadPath} to ${finalDest}.`);
-        yield Downloads.fetch(value.downloadPath, finalDest);
+        if (!callback) {
+            // its likely a single download, so lets show it in download manager, otherwise i wont know when its done
+    		var list = yield Downloads.getList(Downloads.ALL);
+    		var download = yield Downloads.createDownload({
+    			source: value.downloadPath,
+    			target: finalDest
+    		});
+    		list.add(download);
+    		try {
+    			yield download.start();
+    		} finally {
+    			yield download.finalize(true);
+    		}
+        } else {
+            yield Downloads.fetch(value.downloadPath, finalDest);
+        }
         console.log(`${finalDest} has been downloaded`);
         return finalDest;
     }))).then(function(files) {

--- a/index.js
+++ b/index.js
@@ -34,21 +34,16 @@ function download(downloadsArray, callback) {
     Promise.all(downloadsArray.map(Task.async(function*(value, index, array) {
         let finalDest = yield getValidFilename(downloadFolder, value.filename, 0);
         console.log(`Downloading ${value.downloadPath} to ${finalDest}.`);
-        if (!callback) {
-            // its likely a single download, so lets show it in download manager, otherwise i wont know when its done
-            var list = yield Downloads.getList(Downloads.ALL);
-            var download = yield Downloads.createDownload({
-                source: value.downloadPath,
-                target: finalDest
-            });
-            list.add(download);
-            try {
-                yield download.start();
-            } finally {
-                yield download.finalize(true);
-            }
-        } else {
-            yield Downloads.fetch(value.downloadPath, finalDest);
+        var list = yield Downloads.getList(Downloads.ALL);
+        var download = yield Downloads.createDownload({
+            source: value.downloadPath,
+            target: finalDest
+        });
+        list.add(download);
+        try {
+            yield download.start();
+        } finally {
+            yield download.finalize(true);
         }
         console.log(`${finalDest} has been downloaded`);
         return finalDest;

--- a/index.js
+++ b/index.js
@@ -36,17 +36,17 @@ function download(downloadsArray, callback) {
         console.log(`Downloading ${value.downloadPath} to ${finalDest}.`);
         if (!callback) {
             // its likely a single download, so lets show it in download manager, otherwise i wont know when its done
-    		var list = yield Downloads.getList(Downloads.ALL);
-    		var download = yield Downloads.createDownload({
-    			source: value.downloadPath,
-    			target: finalDest
-    		});
-    		list.add(download);
-    		try {
-    			yield download.start();
-    		} finally {
-    			yield download.finalize(true);
-    		}
+            var list = yield Downloads.getList(Downloads.ALL);
+            var download = yield Downloads.createDownload({
+                source: value.downloadPath,
+                target: finalDest
+            });
+            list.add(download);
+            try {
+                yield download.start();
+            } finally {
+                yield download.finalize(true);
+            }
         } else {
             yield Downloads.fetch(value.downloadPath, finalDest);
         }


### PR DESCRIPTION
Connects single downloads to download manager, otherwise we won't know when it's done, and from download manager we can pop it open in file explorer/finder/etc.

For multi downloads, its ok as is, as the multi download usually pops up in version comparator software.
